### PR TITLE
Add missing Close() to header subcommand

### DIFF
--- a/internal/licensei/header.go
+++ b/internal/licensei/header.go
@@ -54,6 +54,7 @@ func (c HeaderChecker) Check(root string, template string) (HeaderViolations, er
 
 			return nil
 		}
+		defer file.Close()
 
 		b := bufio.NewReader(file)
 		var lines string


### PR DESCRIPTION
There was a missing Close() after os.Open that caused `too many open files` errors.