### PR TITLE
Update header check to support multiple years in headers

### DIFF
--- a/internal/licensei/header.go
+++ b/internal/licensei/header.go
@@ -21,8 +21,9 @@ func (c HeaderChecker) Check(root string, template string) (HeaderViolations, er
 	violations := HeaderViolations{}
 
 	template = regexp.QuoteMeta(template)
-	// `([0-9]{4}[,]?[ ]?)+` allows to match multiple appearances of `:YEAR:` that a header might have
-	template = strings.Replace(template, ":YEAR:", "([0-9]{4}[,]?[ ]?)+", -1)
+	// `([0-9]{4}[,]?[\s]?(\band \b)?)+` allows to match multiple appearances of `:YEAR:` that a header might have
+	// for example, "2019 and 2020", or "2019, 2020, and 2021"
+	template = strings.Replace(template, ":YEAR:", "([0-9]{4}[,]?[\\s]?(\\band \\b)?)+", -1)
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
 		if info.IsDir() {

--- a/internal/licensei/header.go
+++ b/internal/licensei/header.go
@@ -21,7 +21,8 @@ func (c HeaderChecker) Check(root string, template string) (HeaderViolations, er
 	violations := HeaderViolations{}
 
 	template = regexp.QuoteMeta(template)
-	template = strings.Replace(template, ":YEAR:", "[0-9]+", -1)
+	// `([0-9]{4}[,]?[ ]?)+` allows to match multiple appearances of `:YEAR:` that a header might have
+	template = strings.Replace(template, ":YEAR:", "([0-9]{4}[,]?[ ]?)+", -1)
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
 		if info.IsDir() {

--- a/internal/licensei/testdata/header/apache_header_multi_years.go
+++ b/internal/licensei/testdata/header/apache_header_multi_years.go
@@ -1,0 +1,15 @@
+// Copyright © 2019, 2020, 2021, 2022, 2023, 2024 Márk Sági-Kazár
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header

--- a/internal/licensei/testdata/header/apache_header_two_years.go
+++ b/internal/licensei/testdata/header/apache_header_two_years.go
@@ -1,4 +1,4 @@
-// Copyright © 2019, 2020, 2021, 2022, 2023, and 2024 Márk Sági-Kazár
+// Copyright © 2019 and 2020 Márk Sági-Kazár
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Motivation
There might be cases we would have multiple years in the file header, for example, company A licensed a package in 2020, then company B acquired company A in 2021 and plan to release a new version for the same package after the acquisition, company B's policy may require the header look like this:
```
// Copyright © 2020 and 2021 company B
...
...
```
or:

```
// Copyright © 2020, 2021 and 2022 company B
...
...
```
This PR is to add support for checking patterns like the above cases

# Changes
Replace `:YEAR:` with regex expression `([0-9]{4}[,]?[\s]?(\band \b)?)`, explanation of the regex expression:
![Screen Shot 2021-08-18 at 3 33 46 PM](https://user-images.githubusercontent.com/29384080/129960793-da675a8a-4a24-4d8b-b87f-76f614f2c1e2.png)


# Results
With the changes, it is able to support the multi-year patterns as shown in the newly added testing headers without changing the usage of the tool