### PR TITLE
Add darwin arm64 build to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
             - darwin
         goarch:
             - amd64
+            - arm64
 
 archives:
     -   name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/.idea/licensei.iml
+++ b/.idea/licensei.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ is_supported_platform() {
   case "$platform" in
     linux/amd64) found=0 ;;
     darwin/amd64) found=0 ;;
+    darwin/arm64) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
Fix issue: https://github.com/goph/licensei/issues/20

Add darwin arm64 build to goreleaser