### PR TITLE
goreleaser download link fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 GOTESTSUM_VERSION = 0.3.5
 GOLANGCI_VERSION = 1.20.0
-GORELEASER_VERSION = 0.119.0
+GORELEASER_VERSION = 1.10.2
 
 GOLANG_VERSION = 1.13
 
@@ -78,7 +78,7 @@ lint: bin/golangci-lint ## Run linter
 
 bin/goreleaser: ## Install goreleaser
 	@mkdir -p ./bin/
-	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | bash -s -- v${GORELEASER_VERSION}
+	scripts/install_goreleaser.sh v${GORELEASER_VERSION}
 
 .PHONY: release
 release: bin/goreleaser ## Release current tag

--- a/scripts/install_goreleaser.sh
+++ b/scripts/install_goreleaser.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+readonly VERSION=${1:-}
+readonly GIT_ROOT="$(git rev-parse --show-toplevel)"
+
+if test "$DISTRIBUTION" = "pro"; then
+	echo "Using Pro distribution..."
+	RELEASES_URL="https://github.com/goreleaser/goreleaser-pro/releases"
+	FILE_BASENAME="goreleaser-pro"
+else
+	echo "Using the OSS distribution..."
+	RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
+	FILE_BASENAME="goreleaser"
+fi
+
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 v{version_to_download}"
+    exit 1
+fi
+
+if [ -x ${GIT_ROOT}/bin/goreleaser-${VERSION} ]; then
+    ln -sf goreleaser-${VERSION} bin/goreleaser
+    echo "GoReleaser ${VERSION} is already installed"
+    exit 0
+fi
+
+test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
+export TAR_FILE="$TMPDIR/${FILE_BASENAME}_$(uname -s)_$(uname -m).tar.gz"
+
+(
+	cd "$TMPDIR"
+	echo "Downloading GoReleaser $VERSION..."
+	curl -sfLo "$TAR_FILE" \
+		"$RELEASES_URL/download/$VERSION/${FILE_BASENAME}_$(uname -s)_$(uname -m).tar.gz"
+	curl -sfLo "checksums.txt" "$RELEASES_URL/download/$VERSION/checksums.txt"
+	curl -sfLo "checksums.txt.sig" "$RELEASES_URL/download/$VERSION/checksums.txt.sig"
+)
+
+tar -xf "$TAR_FILE" -C "$TMPDIR"
+
+mkdir -p ${GIT_ROOT}/bin bin
+mv ${TMPDIR}/goreleaser ${GIT_ROOT}/bin/goreleaser-${VERSION}
+ln -sf goreleaser-${VERSION} bin/goreleaser
+
+echo "GoReleaser ${VERSION} is installed"


### PR DESCRIPTION
## Issue
GORELEASER_VERSION = 0.119.0 is outdated and 
https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh is no longer available for goreleaser installation
Direct download script is not available, so adding a script to download specific version of goreleaser for release

Fixes: https://github.com/goph/licensei/runs/7420268524?check_suite_focus=true

## Test
```
❯ make release
scripts/install_goreleaser.sh v1.10.2
Using the OSS distribution...
Downloading GoReleaser v1.10.2...
GoReleaser v1.10.2 is installed
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
```