### PR TITLE
Support multiple authors in the copyright header

### DIFF
--- a/internal/cmd/licensei/header.go
+++ b/internal/cmd/licensei/header.go
@@ -14,6 +14,7 @@ type headerOptions struct {
 	template    string
 	ignorePaths []string
 	ignoreFiles []string
+	authors     []string
 }
 
 func NewHeaderCommand() *cobra.Command {
@@ -26,6 +27,7 @@ func NewHeaderCommand() *cobra.Command {
 			options.template = viper.GetString("header.template")
 			options.ignorePaths = viper.GetStringSlice("header.ignorePaths")
 			options.ignoreFiles = viper.GetStringSlice("header.ignoreFiles")
+			options.authors = viper.GetStringSlice("header.authors")
 
 			return runHeader(options)
 		},
@@ -43,6 +45,7 @@ func runHeader(options headerOptions) error {
 	violations, err := licensei.HeaderChecker{
 		IgnorePaths: options.ignorePaths,
 		IgnoreFiles: options.ignoreFiles,
+		Authors:     options.authors,
 	}.Check(wd, options.template)
 	if err != nil {
 		return err

--- a/internal/licensei/header.go
+++ b/internal/licensei/header.go
@@ -2,6 +2,7 @@ package licensei
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 type HeaderChecker struct {
 	IgnorePaths []string
 	IgnoreFiles []string
+	Authors     []string
 }
 
 type HeaderViolations map[string]string
@@ -24,6 +26,11 @@ func (c HeaderChecker) Check(root string, template string) (HeaderViolations, er
 	// `([0-9]{4}[,]?[\s]?(\band \b)?)+` allows to match multiple appearances of `:YEAR:` that a header might have
 	// for example, "2019 and 2020", or "2019, 2020, and 2021"
 	template = strings.Replace(template, ":YEAR:", "([0-9]{4}[,]?[\\s]?(\\band \\b)?)+", -1)
+
+	if len(c.Authors) > 0 {
+		authors := fmt.Sprintf(`(\b%s\b)`, strings.Join(c.Authors, `\b|\b`))
+		template = strings.Replace(template, ":AUTHOR:", authors, -1)
+	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
 		if info.IsDir() {

--- a/internal/licensei/header_test.go
+++ b/internal/licensei/header_test.go
@@ -33,3 +33,52 @@ func TestHeaderChecker_Check(t *testing.T) {
 		t.Errorf("%s: %s", violation, path)
 	}
 }
+
+func TestHeaderChecker_Author(t *testing.T) {
+	template := `// Copyright © :YEAR: :AUTHOR:`
+
+	testdata := []struct {
+		valid   bool
+		authors [][]string
+	}{
+		{
+			valid: true,
+			authors: [][]string{
+				{"Márk Sági-Kazár"},
+				{"Márk"},
+				{"Márk", "Jozsi"},
+			},
+		},
+		{
+			valid: false,
+			authors: [][]string{
+				{"Már"},
+				{"Márk Sági-K"},
+				{"Jozsi"},
+			},
+		},
+	}
+
+	for _, td := range testdata {
+		for _, a := range td.authors {
+			checker := HeaderChecker{
+				IgnorePaths: []string{"path"},
+				IgnoreFiles: []string{"*_gen.go", "*_test.go"},
+				Authors:     a,
+			}
+
+			violations, err := checker.Check("testdata/header", template)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if td.valid && len(violations) > 0 {
+				for path, violation := range violations {
+					t.Errorf("%s: %s", violation, path)
+				}
+			} else if !td.valid && len(violations) == 0 {
+				t.Errorf("expected error for authors %+v", a)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Support multiple different authors in the copyright headers, since the author of existing files shouldn't change, but at the same time the author of new source files can be different over time.
